### PR TITLE
[CHG]增加防护代码，避免只hook特定对象并未hook该对象类可能造成的crash

### DIFF
--- a/Stinger/Classes/STHookInfoPool.m
+++ b/Stinger/Classes/STHookInfoPool.m
@@ -224,7 +224,7 @@ static void ffi_function(ffi_cif *cif, void *ret, void **args, void *userdata) {
   memcpy(innerArgs + 2, args + 2, (count - 2) * sizeof(*args));
   
   // before hooks
-  ffi_call_infos(statedClassInfoPool->_beforeInfos);
+  if (statedClassInfoPool) ffi_call_infos(statedClassInfoPool->_beforeInfos);
   if (instanceInfoPool) ffi_call_infos(instanceInfoPool->_beforeInfos);
   
   // instead hooks
@@ -233,7 +233,7 @@ static void ffi_function(ffi_cif *cif, void *ret, void **args, void *userdata) {
     id block = info.block;
     innerArgs[0] = &block;
     ffi_call(&(hookedClassInfoPool->_blockCif), impForBlock(block), ret, innerArgs);
-  } else if (statedClassInfoPool->_insteadInfos.count) {
+  } else if (statedClassInfoPool && statedClassInfoPool->_insteadInfos.count) {
     id <STHookInfo> info = statedClassInfoPool->_insteadInfos[0];
     id block = info.block;
     innerArgs[0] = &block;
@@ -253,7 +253,7 @@ static void ffi_function(ffi_cif *cif, void *ret, void **args, void *userdata) {
     }
   }
   // after hooks
-  ffi_call_infos(statedClassInfoPool->_afterInfos);
+  if (statedClassInfoPool) ffi_call_infos(statedClassInfoPool->_afterInfos);
   if (instanceInfoPool) ffi_call_infos(instanceInfoPool->_afterInfos);
   
   free(innerArgs);


### PR DESCRIPTION
在测试工程中只保留以下hook方法
```
- (void)viewDidLoad {
  [super viewDidLoad];
  // hook for specific instance
  [self st_hookInstanceMethod:@selector(print3:) option:STOptionAfter usingIdentifier:@"hook_print3_after1" withBlock:^(id<StingerParams> params, NSString *s) {
    NSLog(@"---specific instance-self after print3: %@", s);
  }];
}
```
之后调用`@selector(print3:)`方法会引发crash