### PR TITLE
support dynamic block,支持定义通用Block

### DIFF
--- a/Stinger/Classes/STDefines.h
+++ b/Stinger/Classes/STDefines.h
@@ -49,6 +49,7 @@ typedef NS_ENUM(NSInteger, STHookResult) {
 - (id)slf;
 - (SEL)sel;
 - (void)invokeAndGetOriginalRetValue:(void *)retLoc;
+- (NSArray*)getAllArgs;
 @end
 
 

--- a/Stinger/Classes/Stinger.m
+++ b/Stinger/Classes/Stinger.m
@@ -173,8 +173,8 @@ NS_INLINE NSArray<STIdentifier> * getAllIdentifiers(id obj, SEL key) {
 
 
 NS_INLINE BOOL isMatched(STMethodSignature *methodSignature, STMethodSignature *blockSignature, STOption option, Class cls, SEL sel, NSString *identifier) {
-  //argument count
-  if (methodSignature.argumentTypes.count != blockSignature.argumentTypes.count) {
+  //argument count.
+  if (blockSignature.argumentTypes.count > methodSignature.argumentTypes.count) {
     NSCAssert(NO, @"count of arguments isn't equal. Class: (%@), SEL: (%@), Identifier: (%@)", cls, NSStringFromSelector(sel), identifier);
     return NO;
   };
@@ -184,7 +184,7 @@ NS_INLINE BOOL isMatched(STMethodSignature *methodSignature, STMethodSignature *
     return NO;
   }
   // from loc 2.
-  for (NSInteger i = 2; i < methodSignature.argumentTypes.count; i++) {
+  for (NSInteger i = 2; i < blockSignature.argumentTypes.count; i++) {
     if (![blockSignature.argumentTypes[i] isEqualToString:methodSignature.argumentTypes[i]]) {
       NSCAssert(NO, @"argument (%zd) type isn't equal. Class: (%@), SEL: (%@), Identifier: (%@)", i, cls, NSStringFromSelector(sel), identifier);
       return NO;

--- a/Stinger/Classes/StingerParams.m
+++ b/Stinger/Classes/StingerParams.m
@@ -54,4 +54,18 @@
   }
 }
 
+- (NSArray*)getAllArgs{
+    NSMethodSignature *signature = [NSMethodSignature signatureWithObjCTypes:_types.UTF8String];
+    NSInteger count = signature.numberOfArguments;
+    if (count <= 2) {
+        return @[];
+    }
+    NSMutableArray * args = [[NSMutableArray alloc] initWithCapacity:count - 2];
+    for (int i = 2; i < count; i ++) {
+        void **point = _args[i];
+        [args addObject:(__bridge id)(*point)];
+    }
+    return args.copy;
+}
+
 @end


### PR DESCRIPTION
在如下使用场景：定义通用Block
```
for method in methods {
      /// 构造 Block
     let wrappedBlock:StingerBlock = { params in
           self.perform2(name, with: params.getAllArgs)
      }
     self.hook(method.name, position: .before, usingBlock: wrappedBlock)
}
```
批量hook的时候，无法通过代码为每个方法定义block。

本次提交涉及以下修改：
StingerParams协议添加  getAllArgs方法
isMatched函数修改。block参数小于等于原方法参数个数属于验证通过，类型对比以block参数个数为准，定义则对比