### PR TITLE
* StingerParams调用原实现增加支持传入接收target和其余参数

### DIFF
--- a/Stinger/Classes/STDefines.h
+++ b/Stinger/Classes/STDefines.h
@@ -49,7 +49,13 @@ typedef NS_ENUM(NSInteger, STHookResult) {
 - (id)slf;
 - (SEL)sel;
 - (void)invokeAndGetOriginalRetValue:(void *)retLoc;
-- (void)invokeOriginal:(void*)retLoc, ...;
+
+/// 调用原方法实现(IMP).
+- (CFTypeRef)invoke;
+
+/// 调用原方法实现(IMP). 需要传入参数.
+/// @param useless 无用, 随便传什么参数, 一般传nil吧
+- (CFTypeRef)invokeOriginal:(void*)useless, ...;
 @end
 
 

--- a/Stinger/Classes/STDefines.h
+++ b/Stinger/Classes/STDefines.h
@@ -49,11 +49,7 @@ typedef NS_ENUM(NSInteger, STHookResult) {
 - (id)slf;
 - (SEL)sel;
 - (void)invokeAndGetOriginalRetValue:(void *)retLoc;
-
-/// 调用原实现, 需要重新传入消息接收目标target和其余参数(如果有的话)
-/// @param target 接收目标
-/// @return 返回指针, 指向栈上内存
-- (CFTypeRef *)invokeOriginalWithTarget:(id)target, ... ;
+- (void)invokeOriginal:(void*)retLoc, ...;
 @end
 
 

--- a/Stinger/Classes/STDefines.h
+++ b/Stinger/Classes/STDefines.h
@@ -52,8 +52,12 @@ typedef NS_ENUM(NSInteger, STHookResult) {
 
 /// 调用原实现, 需要重新传入消息接收目标target和其余参数(如果有的话)
 /// @param target 接收目标
-- (NSValue *)invokeOriginalWithTarget:(id)target, ... ;
+/// @return 返回指针, 指向栈上内存
+- (void *)invokeOriginalWithTarget:(id)target, ... ;
 @end
+
+#define StingerInvokeOriginal(ReturnType, StingerParams, ...)  \
+*((ReturnType*)[StingerParams invokeOriginalWithTarget:StingerParams.slf, ##__VA_ARGS__])
 
 
 @protocol STHookInfoPool <NSObject>

--- a/Stinger/Classes/STDefines.h
+++ b/Stinger/Classes/STDefines.h
@@ -56,9 +56,6 @@ typedef NS_ENUM(NSInteger, STHookResult) {
 - (void *)invokeOriginalWithTarget:(id)target, ... ;
 @end
 
-#define StingerInvokeOriginal(ReturnType, StingerParams, ...)  \
-*((ReturnType*)[StingerParams invokeOriginalWithTarget:StingerParams.slf, ##__VA_ARGS__])
-
 
 @protocol STHookInfoPool <NSObject>
 @required

--- a/Stinger/Classes/STDefines.h
+++ b/Stinger/Classes/STDefines.h
@@ -49,6 +49,10 @@ typedef NS_ENUM(NSInteger, STHookResult) {
 - (id)slf;
 - (SEL)sel;
 - (void)invokeAndGetOriginalRetValue:(void *)retLoc;
+
+/// 调用原实现, 需要重新传入消息接收目标target和其余参数(如果有的话)
+/// @param target 接收目标
+- (NSValue *)invokeOriginalWithTarget:(id)target, ... ;
 @end
 
 

--- a/Stinger/Classes/STDefines.h
+++ b/Stinger/Classes/STDefines.h
@@ -51,7 +51,7 @@ typedef NS_ENUM(NSInteger, STHookResult) {
 - (void)invokeAndGetOriginalRetValue:(void *)retLoc;
 
 /// 调用原方法实现(IMP).
-- (CFTypeRef)invoke;
+- (CFTypeRef)invokeOriginal;
 
 /// 调用原方法实现(IMP). 需要传入参数.
 /// @param useless 无用, 随便传什么参数, 一般传nil吧

--- a/Stinger/Classes/STDefines.h
+++ b/Stinger/Classes/STDefines.h
@@ -53,7 +53,7 @@ typedef NS_ENUM(NSInteger, STHookResult) {
 /// 调用原实现, 需要重新传入消息接收目标target和其余参数(如果有的话)
 /// @param target 接收目标
 /// @return 返回指针, 指向栈上内存
-- (void *)invokeOriginalWithTarget:(id)target, ... ;
+- (CFTypeRef *)invokeOriginalWithTarget:(id)target, ... ;
 @end
 
 

--- a/Stinger/Classes/StingerParams.m
+++ b/Stinger/Classes/StingerParams.m
@@ -54,7 +54,7 @@
   }
 }
 
-- (CFTypeRef)invoke {
+- (CFTypeRef)invokeOriginal {
   NSMethodSignature *signature = [NSMethodSignature signatureWithObjCTypes:_types.UTF8String];
   NSInteger count = signature.numberOfArguments;
   NSInvocation *originalInvocation = [NSInvocation invocationWithMethodSignature:signature];

--- a/Stinger/Classes/StingerParams.m
+++ b/Stinger/Classes/StingerParams.m
@@ -55,7 +55,7 @@
   }
 }
 
-- (void *)invokeOriginalWithTarget:(id)target, ... {
+- (CFTypeRef *)invokeOriginalWithTarget:(id)target, ... {
     NSMethodSignature *signature = [NSMethodSignature signatureWithObjCTypes:_types.UTF8String];
     NSInvocation *inv = [NSInvocation invocationWithMethodSignature:signature];
     // 传参
@@ -249,7 +249,7 @@ else if (size <= 4 * _size_ ) { \
         // 申请栈上内存
         void *buffer = alloca(returnSize);
         [inv getReturnValue:buffer];
-        return buffer;
+        return (CFTypeRef*)buffer;
     }
     return nil;
 }

--- a/Stinger/Classes/StingerParams.m
+++ b/Stinger/Classes/StingerParams.m
@@ -7,6 +7,7 @@
 //
 
 #import "StingerParams.h"
+#import <objc/runtime.h>
 
 @interface NSInvocation (STInvoke)
 - (void)invokeUsingIMP:(IMP)imp;
@@ -52,6 +53,214 @@
   if (originalInvocation.methodSignature.methodReturnLength && !(retLoc == NULL)) {
     [originalInvocation getReturnValue:retLoc];
   }
+}
+
+- (NSValue *)invokeOriginalWithTarget:(id)target, ... {
+    NSMethodSignature *signature = [NSMethodSignature signatureWithObjCTypes:_types.UTF8String];
+    NSInteger count = signature.numberOfArguments;
+    NSInvocation *inv = [NSInvocation invocationWithMethodSignature:signature];
+    // 传参
+    [inv setTarget:target];
+    [inv setArgument:_args[1] atIndex:1];
+    
+    va_list args;
+    va_start(args, target);
+    
+    for (int index = 2; index < count; index++) {
+        char *type = (char *)[signature getArgumentTypeAtIndex:index];
+        while (*type == 'r' || // const
+               *type == 'n' || // in
+               *type == 'N' || // inout
+               *type == 'o' || // out
+               *type == 'O' || // bycopy
+               *type == 'R' || // byref
+               *type == 'V') { // oneway
+            type++; // cutoff useless prefix
+        }
+        
+        BOOL unsupportedType = NO;
+        switch (*type) {
+            case 'v': // 1: void
+            case 'B': // 1: bool
+            case 'c': // 1: char / BOOL
+            case 'C': // 1: unsigned char
+            case 's': // 2: short
+            case 'S': // 2: unsigned short
+            case 'i': // 4: int / NSInteger(32bit)
+            case 'I': // 4: unsigned int / NSUInteger(32bit)
+            case 'l': // 4: long(32bit)
+            case 'L': // 4: unsigned long(32bit)
+            { // 'char' and 'short' will be promoted to 'int'.
+                int arg = va_arg(args, int);
+                [inv setArgument:&arg atIndex:index];
+            } break;
+                
+            case 'q': // 8: long long / long(64bit) / NSInteger(64bit)
+            case 'Q': // 8: unsigned long long / unsigned long(64bit) / NSUInteger(64bit)
+            {
+                long long arg = va_arg(args, long long);
+                [inv setArgument:&arg atIndex:index];
+            } break;
+                
+            case 'f': // 4: float / CGFloat(32bit)
+            { // 'float' will be promoted to 'double'.
+                double arg = va_arg(args, double);
+                float argf = arg;
+                [inv setArgument:&argf atIndex:index];
+            } break;
+                
+            case 'd': // 8: double / CGFloat(64bit)
+            {
+                double arg = va_arg(args, double);
+                [inv setArgument:&arg atIndex:index];
+            } break;
+                
+            case 'D': // 16: long double
+            {
+                long double arg = va_arg(args, long double);
+                [inv setArgument:&arg atIndex:index];
+            } break;
+                
+            case '*': // char *
+            case '^': // pointer
+            {
+                void *arg = va_arg(args, void *);
+                [inv setArgument:&arg atIndex:index];
+            } break;
+                
+            case ':': // SEL
+            {
+                SEL arg = va_arg(args, SEL);
+                [inv setArgument:&arg atIndex:index];
+            } break;
+                
+            case '#': // Class
+            {
+                Class arg = va_arg(args, Class);
+                [inv setArgument:&arg atIndex:index];
+            } break;
+                
+            case '@': // id
+            {
+                id arg = va_arg(args, id);
+                [inv setArgument:&arg atIndex:index];
+            } break;
+                
+            case '{': // struct
+            {
+                if (strcmp(type, @encode(CGPoint)) == 0) {
+                    CGPoint arg = va_arg(args, CGPoint);
+                    [inv setArgument:&arg atIndex:index];
+                } else if (strcmp(type, @encode(CGSize)) == 0) {
+                    CGSize arg = va_arg(args, CGSize);
+                    [inv setArgument:&arg atIndex:index];
+                } else if (strcmp(type, @encode(CGRect)) == 0) {
+                    CGRect arg = va_arg(args, CGRect);
+                    [inv setArgument:&arg atIndex:index];
+                } else if (strcmp(type, @encode(CGVector)) == 0) {
+                    CGVector arg = va_arg(args, CGVector);
+                    [inv setArgument:&arg atIndex:index];
+                } else if (strcmp(type, @encode(CGAffineTransform)) == 0) {
+                    CGAffineTransform arg = va_arg(args, CGAffineTransform);
+                    [inv setArgument:&arg atIndex:index];
+                } else if (strcmp(type, @encode(CATransform3D)) == 0) {
+                    CATransform3D arg = va_arg(args, CATransform3D);
+                    [inv setArgument:&arg atIndex:index];
+                } else if (strcmp(type, @encode(NSRange)) == 0) {
+                    NSRange arg = va_arg(args, NSRange);
+                    [inv setArgument:&arg atIndex:index];
+                } else if (strcmp(type, @encode(UIOffset)) == 0) {
+                    UIOffset arg = va_arg(args, UIOffset);
+                    [inv setArgument:&arg atIndex:index];
+                } else if (strcmp(type, @encode(UIEdgeInsets)) == 0) {
+                    UIEdgeInsets arg = va_arg(args, UIEdgeInsets);
+                    [inv setArgument:&arg atIndex:index];
+                } else {
+                    unsupportedType = YES;
+                }
+            } break;
+                
+            case '(': // union
+            {
+                unsupportedType = YES;
+            } break;
+                
+            case '[': // array
+            {
+                unsupportedType = YES;
+            } break;
+                
+            default: // what?!
+            {
+                unsupportedType = YES;
+            } break;
+        }
+        
+        if (unsupportedType) {
+            // Try with some dummy type...
+            
+            NSUInteger size = 0;
+            NSGetSizeAndAlignment(type, &size, NULL);
+            
+#define case_size(_size_) \
+else if (size <= 4 * _size_ ) { \
+    struct dummy { char tmp[4 * _size_]; }; \
+    struct dummy arg = va_arg(args, struct dummy); \
+    [inv setArgument:&arg atIndex:index]; \
+}
+            if (size == 0) { }
+            case_size( 1) case_size( 2) case_size( 3) case_size( 4)
+            case_size( 5) case_size( 6) case_size( 7) case_size( 8)
+            case_size( 9) case_size(10) case_size(11) case_size(12)
+            case_size(13) case_size(14) case_size(15) case_size(16)
+            case_size(17) case_size(18) case_size(19) case_size(20)
+            case_size(21) case_size(22) case_size(23) case_size(24)
+            case_size(25) case_size(26) case_size(27) case_size(28)
+            case_size(29) case_size(30) case_size(31) case_size(32)
+            case_size(33) case_size(34) case_size(35) case_size(36)
+            case_size(37) case_size(38) case_size(39) case_size(40)
+            case_size(41) case_size(42) case_size(43) case_size(44)
+            case_size(45) case_size(46) case_size(47) case_size(48)
+            case_size(49) case_size(50) case_size(51) case_size(52)
+            case_size(53) case_size(54) case_size(55) case_size(56)
+            case_size(57) case_size(58) case_size(59) case_size(60)
+            case_size(61) case_size(62) case_size(63) case_size(64)
+            else {
+                /*
+                 Larger than 256 byte?! I don't want to deal with this stuff up...
+                 Ignore this argument.
+                 */
+                struct dummy {char tmp;};
+                for (int i = 0; i < size; i++) va_arg(args, struct dummy);
+                NSLog(@"StingerParams invokeOriginalAndGetReturnValue unsupported type:%s (%lu bytes)",
+                      [signature getArgumentTypeAtIndex:index],(unsigned long)size);
+            }
+#undef case_size
+
+        }
+    }
+    
+    va_end(args);
+    
+    // 调用原实现
+    [inv invokeUsingIMP:_originalIMP];
+    NSUInteger returnSize = inv.methodSignature.methodReturnLength;
+    if (returnSize) {
+        void *buffer = malloc(returnSize);
+        [inv getReturnValue:buffer];
+        NSData *data = [NSData dataWithBytesNoCopy:buffer length:returnSize freeWhenDone:YES];
+        NSValue *retValue =
+        [NSValue valueWithBytes:buffer
+                       objCType:inv.methodSignature.methodReturnType];
+        objc_setAssociatedObject(retValue, "StingerReturnData",
+                                 data, OBJC_ASSOCIATION_COPY_NONATOMIC);
+        return retValue;
+    }
+    return nil;
+}
+
+- (void)dtdd {
+    
 }
 
 @end


### PR DESCRIPTION
我在使用时遇到一种场景, 需要钩带block参数的方法，如：
- (void)doSomthing:(void(^)(void))block;
然后，替换调原block，做一些处理之后再调用原block，如：
- (void)doSomthing:(void(^)(void))block {
    [self doSomthing:^{
        NSLog(@"做些其他事情");
        !block?:block();
    }];
}

以上情况，需要用instead模式钩住原方法，然后再在钩子里调用原方法传入新的block处理，再在新block调用原block。所以我给StingerParams新增实现了一个可以传入target和其余参数的invoke方法